### PR TITLE
Remove patching of removed source files

### DIFF
--- a/net-misc/lbryum/lbryum-9999.ebuild
+++ b/net-misc/lbryum/lbryum-9999.ebuild
@@ -1,6 +1,5 @@
-# Copyright 1999-2016 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
-# $Id$
 
 EAPI="5"
 
@@ -45,33 +44,9 @@ DEPEND="
 	sys-apps/sed
 	"
 
-DOCS="RELEASE-NOTES"
-
 src_prepare() {
-	# Don't advise using PIP
-	sed -i "s/On Linux, try 'sudo pip install zbar'/Re-emerge lbryum with the qrcode USE flag/" lib/qrscanner.py || die
-
 	# Prevent icon from being installed in the wrong location
 	sed -i '/icons/d' setup.py || die
-
-	# Remove unrequested GUI implementations:
-	rm -rf gui/android*
-	rm -rf gui/jsonrpc*
-	rm -rf gui/kivy*
-	local gui
-	for gui in  \
-		$(usex cli      '' stdio)  \
-		$(usex qt4      '' qt   )  \
-		$(usex ncurses  '' text )  \
-	; do
-		rm gui/"${gui}"* -r || die
-	done
-
-	if ! use qt4; then
-		sed -i "s/'electrum_gui\\.qt',//" setup.py || die
-		local bestgui=$(usex ncurses text stdio)
-		sed -i "s/\(config.get('gui', \?\)'classic'/\1'${bestgui}'/" electrum || die
-	fi
 
 	distutils-r1_src_prepare
 }


### PR DESCRIPTION
In combination with #3, #4, and #5, this enables building all dependencies for `net-p2p/lbry-9999`.
However, this whole repository seems to be completely outdated with respect to https://github.com/lbryio/lbry .
I see two solutions:

1. Adjust the `net-p2p/lbry` ebuild to build from an old commit compatible to the dependencies here.
2. Update this whole repository to work with the latest master.

Obviously, the 2nd option would be preferable but I'm afraid this is a bit beyond my capabilities.
The 1st option would at least make it possible to install LRBY at all on Gentoo.

Is there any maintainer of this overlay?
@whitslack? @lyoshenka?

Is there any better place to discuss these things? This repository doesn't even have issues activated after all.